### PR TITLE
Expose AST types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type * from "./ast/ast"
+
 export type {DisassembleAndProcessParams, DisassembleParams} from "./decompiler/disasm"
 export {
     disassemble,


### PR DESCRIPTION
Functions such as `disassembleAndProcess` return AST, but it was not exported